### PR TITLE
add build/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configurar Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+          playwright install
+
+      - name: Migraciones
+        run: python manage.py migrate
+
+      - name: Cargar datos iniciales
+        run: python manage.py loaddata fixtures/events.json
+
+  tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+          playwright install
+
+      - name: Migraciones y datos
+        run: |
+          python manage.py migrate
+          python manage.py loaddata fixtures/events.json
+
+      - name: Tests Unitarios e Integración
+        run: |
+          python manage.py test app.test.test_unit
+          python manage.py test app.test.test_integration
+
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+          playwright install
+
+      - name: Migraciones y datos
+        run: |
+          python manage.py migrate
+          python manage.py loaddata fixtures/events.json
+
+      - name: Run Server & e2e tests
+        run: |
+          nohup python manage.py runserver 0.0.0.0:8000 &
+          sleep 5
+          python manage.py test app.test.test_e2e


### PR DESCRIPTION
*Se cerro la otra rama (romekai-ci)a causa de usar la interfaz y mala nomenclatura de la misma*

Configuré un workflow que se corre automáticamente al hacer push o pull request sobre main. El CI incluye:
3 jobs que complen las tareas de:
Instalación de dependencias y Playwright
Aplicación de migraciones y carga de datos iniciales (fixtures/events.json)
Ejecución de tests unitarios, de integración y e2e.